### PR TITLE
BLUE-243 | Mapping fixed toolbar container prop to the tinymce component in editable html tm package

### DIFF
--- a/packages/config-ui/src/choice-configuration/index.jsx
+++ b/packages/config-ui/src/choice-configuration/index.jsx
@@ -46,7 +46,7 @@ const EditableHtmlContainer = withStyles(theme => ({
             imageSupport={imageSupport}
             className={classes.editor}
             toolbarOpts={toolbarOpts}
-            fixedToolbarContainer='#jg-foobar-toolbar-x'
+            fixedToolbarContainer={fixedToolbarContainer}
             onBlur={onBlur}
             tinyMCEApiKey={tinyMCEApiKey}
           />

--- a/packages/config-ui/src/choice-configuration/index.jsx
+++ b/packages/config-ui/src/choice-configuration/index.jsx
@@ -28,7 +28,10 @@ const EditableHtmlContainer = withStyles(theme => ({
     imageSupport,
     disabled,
     nonEmpty,
-    toolbarOpts
+    toolbarOpts,
+    fixedToolbarContainer = '',
+    onBlur = () => {},
+    tinyMCEApiKey = '',
   }) => {
     const names = classNames(classes.labelContainer, className);
 
@@ -43,6 +46,9 @@ const EditableHtmlContainer = withStyles(theme => ({
             imageSupport={imageSupport}
             className={classes.editor}
             toolbarOpts={toolbarOpts}
+            fixedToolbarContainer='#jg-foobar-toolbar-x'
+            onBlur={onBlur}
+            tinyMCEApiKey={tinyMCEApiKey}
           />
         </div>
       </InputContainer>
@@ -63,7 +69,7 @@ const Feedback = withStyles(() => ({
     position: 'absolute',
     top: 20
   }
-}))(({ value, onChange, type, correct, classes, defaults, toolbarOpts }) => {
+}))(({ value, onChange, type, correct, classes, defaults, toolbarOpts, fixedToolbarContainer = '', onBlur = () => {}, tinyMCEApiKey = '', }) => {
   if (!type || type === 'none') {
     return null;
   } else if (type === 'default') {
@@ -87,6 +93,9 @@ const Feedback = withStyles(() => ({
           value={value}
           onChange={onChange}
           toolbarOpts={toolbarOpts}
+          fixedToolbarContainer={fixedToolbarContainer}
+          onBlur={onBlur}
+          tinyMCEApiKey={tinyMCEApiKey}
         />
       </div>
     );
@@ -196,7 +205,10 @@ export class ChoiceConfiguration extends React.Component {
       allowDelete,
       toolbarOpts,
       inputToggleDisabled,
-      dragHandleProps
+      dragHandleProps,
+      fixedToolbarContainer = '',
+      onBlur = () => { },
+      tinyMCEApiKey = '',
     } = this.props;
 
     const InputToggle = mode === 'checkbox' ? InputCheckbox : InputRadio;
@@ -224,6 +236,9 @@ export class ChoiceConfiguration extends React.Component {
               onChange={this.onLabelChange}
               imageSupport={imageSupport}
               disabled={disabled}
+              fixedToolbarContainer={fixedToolbarContainer}
+              onBlur={onBlur}
+              tinyMCEApiKey={tinyMCEApiKey}
               nonEmpty={nonEmpty}
               toolbarOpts={toolbarOpts}
             />

--- a/packages/editable-html-tm/src/index.jsx
+++ b/packages/editable-html-tm/src/index.jsx
@@ -81,41 +81,89 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
             tiny_mce_wiris: '/@wiris/mathtype-tinymce5/plugin.min.js'
           },
           plugins: [
-            'advlist',
-            'anchor',
-            'autolink',
-            'charmap',
-            'code',
-            'fullscreen',
-            'help',
-            'image imagetools',
-            'insertdatetime',
-            'link',
-            'lists',
-            'media',
-            'paste',
-            'preview',
-            'print',
-            'searchreplace',
-            'table',
-            'visualblocks',
-            'wordcount'
+            'preview ' +
+            'paste ' +
+            'importcss ' +
+            'searchreplace ' +
+            'autolink ' +
+            'autosave ' +
+            'directionality ' +
+            'code ' +
+            'visualblocks ' +
+            'visualchars ' +
+            'fullscreen ' +
+            'image ' +
+            'link ' +
+            'media ' +
+            'template ' +
+            'codesample ' +
+            'table ' +
+            'charmap ' +
+            'hr ' +
+            'nonbreaking ' +
+            'anchor ' +
+            'toc ' +
+            'insertdatetime ' +
+            'advlist ' +
+            'lists ' +
+            'wordcount ' +
+            'imagetools ' +
+            'textpattern ' +
+            'noneditable ' +
+            'help ' +
+            'charmap ' +
+            'contextmenu ' +
+            'emoticons',
           ],
           toolbar_mode: 'sliding',
           toolbar: [
-            'bold italic underline strikethrough alignleft aligncenter alignright alignjustify table code | fullscreen',
-            'formatselect link anchor',
-            'outdent indent numlist bullist checklist',
-            'forecolor backcolor casechange permanentpen formatpainter removeformat',
-            'pagebreak',
-            'charmap emoticons',
-            'save print insertfile image media pageembed template',
-            'a11ycheck ltr rtl',
-            'showcomments addcomment searchreplace tiny_mce_wiris_formulaEditor tiny_mce_wiris_formulaEditorChemistry',
-          ].join(' | '),
+            'undo',
+            'redo |',
+            'bold',
+            'italic',
+            'underline',
+            'strikethrough |',
+            'fontselect',
+            'fontsizeselect',
+            'formatselect |',
+            'alignleft',
+            'aligncenter',
+            'alignright',
+            'alignjustify |',
+            'outdent',
+            'indent |',
+            'numlist',
+            'bullist |',
+            'forecolor',
+            'backcolor',
+            'removeformat |',
+            'charmap',
+            'emoticons |',
+            'fullscreen',
+            'preview',
+            'insertfile |',
+            'table',
+            'tabledelete',
+            'tableprops',
+            'tablerowprops',
+            'tablecellprops |',
+            'tableinsertrowbefore',
+            'tableinsertrowafter',
+            'tabledeleterow |',
+            'tableinsertcolbefore',
+            'tableinsertcolafter',
+            'tabledeletecol |',
+            'image',
+            'link',
+            'anchor',
+            'codesample',
+          ].join(' '),
           htmlAllowedTags: ['.*'],
           htmlAllowedAttrs: ['.*'],
           draggable_modal: true,
+          setup: (editor) => {
+            editor.on('blur', () => typeof onBlur === 'function' ? onBlur() : onBlur);
+          },
           images_upload_handler: dataImageHandler,
           content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }'
         }}

--- a/packages/editable-html-tm/src/index.jsx
+++ b/packages/editable-html-tm/src/index.jsx
@@ -38,7 +38,7 @@ function dataImageHandler(blobInfo, success, failure, progress) {
   }, 500);
 }
 
-function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFormat, onBlur, onFocus }) {
+function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFormat, onBlur, onFocus, fixedToolbarContainer }) {
 
   const editorRef = useRef(null);
 
@@ -75,6 +75,7 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
           paste_data_images: true,
           object_resizing: true,
           automatic_uploads: false,
+          fixed_toolbar_container: fixedToolbarContainer,
           external_plugins: {
             // this needs to be setup in the parent project
             tiny_mce_wiris: '/@wiris/mathtype-tinymce5/plugin.min.js'

--- a/packages/editable-html-tm/src/index.jsx
+++ b/packages/editable-html-tm/src/index.jsx
@@ -38,7 +38,7 @@ function dataImageHandler(blobInfo, success, failure, progress) {
   }, 500);
 }
 
-function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFormat, onBlur, onFocus, fixedToolbarContainer }) {
+function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFormat, onBlur, onFocus, fixedToolbarContainer, tinyMCEApiKey }) {
 
   const editorRef = useRef(null);
 
@@ -59,7 +59,7 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
     <div className={classes.editorWrapper}>
       <Editor
         className={classes.editContainer}
-        apiKey="jia0ekj0smryac6bkoratszcr5zks933f60faprd3b30work"
+        apiKey={tinyMCEApiKey || ''}
         onInit={(evt, editor) => (editorRef.current = editor)}
         value={markup}
         onBlur={onBlur}


### PR DESCRIPTION
This PR simply maps new props provided from the calling component (i.e. [multiple-choice component](https://github.com/TeachForward/pie-elements-private/pull/25)) to the tinymce toolbar in editable-html-tm. Also includes updates to the choice-configuration components to map these same props from a [calling component](https://github.com/TeachForward/acer-item-author-ui/pull/220) to the same editable-html-tm.

Relates to PRs: https://github.com/TeachForward/acer-item-author-ui/pull/220 and https://github.com/TeachForward/pie-elements-private/pull/25