### PR TITLE
Disabling the wiris plugin in editable-html-tm

### DIFF
--- a/packages/config-ui/package.json
+++ b/packages/config-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teachforward/config-ui",
-  "version": "10.10.20",
+  "version": "10.10.21",
   "main": "lib/index.js",
   "module": "src/index.js",
   "repository": {
@@ -15,7 +15,7 @@
   "dependencies": {
     "@material-ui/core": "^3.8.3",
     "@material-ui/icons": "^3.0.2",
-    "@teachforward/editable-html-tm": "^1.0.13",
+    "@teachforward/editable-html-tm": "^1.0.14",
     "@pie-lib/icons": "^2.4.25",
     "@pie-lib/render-ui": "^4.11.9",
     "react-beautiful-dnd": "^13.1.0",

--- a/packages/editable-html-tm/package.json
+++ b/packages/editable-html-tm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teachforward/editable-html-tm",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "",
   "license": "ISC",
   "main": "lib/index.js",

--- a/packages/editable-html-tm/src/index.jsx
+++ b/packages/editable-html-tm/src/index.jsx
@@ -78,7 +78,16 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
           browser_spellcheck: browserSpellCheck,
           external_plugins: {
             // this needs to be setup in the parent project
-            tiny_mce_wiris: '/@wiris/mathtype-tinymce5/plugin.min.js'
+            // tiny_mce_wiris: '/@wiris/mathtype-tinymce5/plugin.min.js'
+
+            // JG - turning off wiris plugin for now... seems to be
+            // causing issues with (at least) match type when loading
+            // the pie element multiple times. The effect is that it's
+            // setting the first row's title to the default value
+            // immediately after setting the value to what it should
+            // be in the model. (See:
+            // https://educopiallc.atlassian.net/browse/BLUE-1175 and
+            // https://educopiallc.atlassian.net/browse/BLUE-344)
           },
           plugins: [
             'preview ' +
@@ -86,7 +95,6 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
             'importcss ' +
             'searchreplace ' +
             'autolink ' +
-            'autosave ' +
             'directionality ' +
             'code ' +
             'visualblocks ' +
@@ -102,7 +110,6 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
             'hr ' +
             'nonbreaking ' +
             'anchor ' +
-            'toc ' +
             'insertdatetime ' +
             'advlist ' +
             'lists ' +
@@ -112,7 +119,6 @@ function EditorHtml({ classes, markup, onChange, onDone, height, width, outputFo
             'noneditable ' +
             'help ' +
             'charmap ' +
-            'contextmenu ' +
             'emoticons',
           ],
           toolbar_mode: 'sliding',


### PR DESCRIPTION
Why:
It's causing issues with CMC, see comment thread in https://educopiallc.atlassian.net/browse/BLUE-344

How:
Updated tinymce plugin setup in editable-html-tm component

Jira:
BLUE-1175

Tags:
tinymce wiris math complex multiple choice